### PR TITLE
http_emitter_timeout rename and add default value

### DIFF
--- a/emitter.py
+++ b/emitter.py
@@ -72,7 +72,7 @@ def sanitize_payload(item, log, sanitize_func):
 def http_emitter(message, log, agentConfig, endpoint):
     "Send payload"
     url = agentConfig['dd_url']
-    http_emmiter_timeout = float(agentConfig['http_emmiter_timeout'])
+    http_emitter_timeout = float(agentConfig.get('http_emitter_timeout', 5))
 
     log.debug('http_emitter: attempting postback to ' + url)
 
@@ -113,7 +113,7 @@ def http_emitter(message, log, agentConfig, endpoint):
 
     try:
         headers = post_headers(agentConfig, zipped)
-        r = requests.post(url, data=zipped, timeout=http_emmiter_timeout, headers=headers)
+        r = requests.post(url, data=zipped, timeout=http_emitter_timeout, headers=headers)
 
         r.raise_for_status()
 

--- a/stackstate.conf.example
+++ b/stackstate.conf.example
@@ -27,7 +27,7 @@ api_key: none
 # tags: mytag, env:prod, role:database
 
 # Timeout in seconds for requests to for StackState intake api
-http_emmiter_timeout=60
+http_emitter_timeout=60
 
 # Set timeout in seconds for outgoing requests to StackState. (default: 20)
 # When a request timeout, it will be retried after some time.


### PR DESCRIPTION
CI couldn't find `http_emmiter_timeout` in its settings, added a default value when the value isn't present in the configuration.