### PR TITLE
fix NTP check

### DIFF
--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -596,7 +596,7 @@ class TestCore(unittest.TestCase):
         except Exception:
             pass
 
-        self.assertTrue(ntp_util.args["host"].endswith("stackstate.pool.ntp.org"))
+        self.assertTrue(ntp_util.args["host"].endswith("pool.ntp.org"))
         self.assertEqual(ntp_util.args["port"], "ntp")
         self.assertEqual(ntp_util.args["version"], 3)
         self.assertEqual(ntp_util.args["timeout"], 1.0)

--- a/utils/ntp.py
+++ b/utils/ntp.py
@@ -26,7 +26,7 @@ class NTPUtil():
         except Exception:
             settings = {}
 
-        self.host = settings.get('host') or "{0}.stackstate.pool.ntp.org".format(random.randint(0, 3))
+        self.host = settings.get('host') or "{0}.pool.ntp.org".format(random.randint(0, 3))
         self.version = int(settings.get("version") or NTPUtil.DEFAULT_VERSION)
         self.port = settings.get('port') or NTPUtil.DEFAULT_PORT
         self.timeout = float(settings.get('timeout') or NTPUtil.DEFAULT_TIMEOUT)


### PR DESCRIPTION
Datadog uses its own NTP pool, this was wrongly renamed. Now we just use {0-3}.pool.ntp.org.