### PR TITLE
limit the number of results from agent config’s grep

### DIFF
--- a/connbeat.sh
+++ b/connbeat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export STSURL="`grep '^dd_url: ' /etc/sts-agent/stackstate.conf | sed 's/^dd_url: //'`"
-export APIKEY="`grep '^api_key: ' /etc/sts-agent/stackstate.conf | sed 's/^api_key: //'`"
+export STSURL="`grep -m 1 '^dd_url: ' /etc/sts-agent/stackstate.conf | sed 's/^dd_url: //'`"
+export APIKEY="`grep -m 1 '^api_key: ' /etc/sts-agent/stackstate.conf | sed 's/^api_key: //'`"
 
 exec /opt/stackstate-agent/bin/connbeat -c /etc/sts-agent/connbeat.yml -path.logs /var/log/stackstate -path.data /var/lib/stackstate/connbeat


### PR DESCRIPTION
Connection beat is started through a bash file. The bash file greps stackstate-agent's config file for its dd_url and api_key. However, the content of the config file may be duplicated, by some reason, which results in duplicate entries in both variables separated by a newline character. This manifested in connectionbeat sending wrong http headers because of the grep injected newline character.

Solution: limit the grep to a maximum of one result. Which is also more efficient in searching the config file ;p