### PR TITLE
Splunk deduplication with custom fields

### DIFF
--- a/checks.d/splunk_event.py
+++ b/checks.d/splunk_event.py
@@ -44,6 +44,7 @@ class SplunkEvent(SplunkTelemetryBase):
             'default_max_restart_history_seconds': 86400,
             'default_max_query_chunk_seconds': 3600,
             'default_initial_delay_seconds': 0,
+            'default_fields_for_identification': ["_bkt", "_cd"]
         })
         event_saved_searches = SavedSearches([
             EventSavedSearch(metric_instance_config, saved_search_instance)

--- a/checks.d/splunk_event.py
+++ b/checks.d/splunk_event.py
@@ -44,7 +44,7 @@ class SplunkEvent(SplunkTelemetryBase):
             'default_max_restart_history_seconds': 86400,
             'default_max_query_chunk_seconds': 3600,
             'default_initial_delay_seconds': 0,
-            'default_fields_for_identification': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"]
         })
         event_saved_searches = SavedSearches([
             EventSavedSearch(metric_instance_config, saved_search_instance)

--- a/checks.d/splunk_event.py
+++ b/checks.d/splunk_event.py
@@ -4,7 +4,7 @@
 
 # 3rd party
 
-from utils.splunk.splunk import SplunkInstanceConfig, SavedSearches
+from utils.splunk.splunk import SplunkTelemetryInstanceConfig, SavedSearches
 from utils.splunk.splunk_telemetry import SplunkTelemetryInstance, SplunkTelemetrySavedSearch
 from utils.splunk.splunk_telemetry_base import SplunkTelemetryBase
 
@@ -33,7 +33,7 @@ class SplunkEvent(SplunkTelemetryBase):
         self.event(kwargs)
 
     def get_instance(self, instance, current_time):
-        metric_instance_config = SplunkInstanceConfig(instance, self.init_config, {
+        metric_instance_config = SplunkTelemetryInstanceConfig(instance, self.init_config, {
             'default_request_timeout_seconds': 5,
             'default_search_max_retry_count': 3,
             'default_search_seconds_between_retries': 1,

--- a/checks.d/splunk_metric.py
+++ b/checks.d/splunk_metric.py
@@ -61,7 +61,7 @@ class SplunkMetric(SplunkTelemetryBase):
             'default_max_restart_history_seconds': 86400,
             'default_max_query_chunk_seconds': 3600,
             'default_initial_delay_seconds': 0,
-            'default_fields_for_identification': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"]
         })
         metric_saved_searches = SavedSearches([
             MetricSavedSearch(metric_instance_config, saved_search_instance)

--- a/checks.d/splunk_metric.py
+++ b/checks.d/splunk_metric.py
@@ -4,7 +4,7 @@
 
 # 3rd party
 
-from utils.splunk.splunk import SplunkInstanceConfig, SavedSearches
+from utils.splunk.splunk import SplunkTelemetryInstanceConfig, SavedSearches
 from utils.splunk.splunk_telemetry import SplunkTelemetryInstance, SplunkTelemetrySavedSearch
 from utils.splunk.splunk_telemetry_base import SplunkTelemetryBase
 
@@ -48,7 +48,7 @@ class SplunkMetric(SplunkTelemetryBase):
         self.raw(metric, float(value), **kwargs)
 
     def get_instance(self, instance, current_time):
-        metric_instance_config = SplunkInstanceConfig(instance, self.init_config, {
+        metric_instance_config = SplunkTelemetryInstanceConfig(instance, self.init_config, {
             'default_request_timeout_seconds': 5,
             'default_search_max_retry_count': 3,
             'default_search_seconds_between_retries': 1,

--- a/checks.d/splunk_metric.py
+++ b/checks.d/splunk_metric.py
@@ -61,6 +61,7 @@ class SplunkMetric(SplunkTelemetryBase):
             'default_max_restart_history_seconds': 86400,
             'default_max_query_chunk_seconds': 3600,
             'default_initial_delay_seconds': 0,
+            'default_fields_for_identification': ["_bkt", "_cd"]
         })
         metric_saved_searches = SavedSearches([
             MetricSavedSearch(metric_instance_config, saved_search_instance)

--- a/conf.d/splunk_event.yaml.example
+++ b/conf.d/splunk_event.yaml.example
@@ -31,8 +31,8 @@ init_config:
   # Delay before starting polling events after starting
   # default_initial_delay_seconds: 600
 
-  # Fields to uniquely identify a record. Use fields_for_identification: None to use the whole record.
-  # default_fields_for_identification:
+  # Fields to uniquely identify a record. Use unique_key_fields: None to use the whole record.
+  # default_unique_key_fields:
   #   - "_bkt"
   #   - "_cd"
 
@@ -57,7 +57,7 @@ instances:
         # initial_history_time_seconds: 0
         # max_restart_history_seconds: 86400
         # max_query_chunk_seconds: 3600
-        # fields_for_identification:
+        # unique_key_fields:
         #   - "_bkt"
         #   - "_cd"
 

--- a/conf.d/splunk_event.yaml.example
+++ b/conf.d/splunk_event.yaml.example
@@ -31,6 +31,11 @@ init_config:
   # Delay before starting polling events after starting
   # default_initial_delay_seconds: 600
 
+  # Fields to uniquely identify a record. Use fields_for_identification: None to use the whole record.
+  # default_fields_for_identification:
+  #   - "_bkt"
+  #   - "_cd"
+
 # Currently it is not possible to specify multiple instances with the same url.
 # It is possible to specify multiple saved_searches on a single instance.
 instances:
@@ -52,6 +57,9 @@ instances:
         # initial_history_time_seconds: 0
         # max_restart_history_seconds: 86400
         # max_query_chunk_seconds: 3600
+        # fields_for_identification:
+        #   - "_bkt"
+        #   - "_cd"
 
         # Additional parameters for the splunk saved search query
         parameters:

--- a/conf.d/splunk_metric.yaml.example
+++ b/conf.d/splunk_metric.yaml.example
@@ -35,8 +35,8 @@ init_config:
   # The metric value field should contain numerical data in the splunk results
   # default_metric_value_field: "value"
 
-  # Fields to uniquely identify a record. Use fields_for_identification: None to use the whole record.
-  # default_fields_for_identification:
+  # Fields to uniquely identify a record. Use unique_key_fields: None to use the whole record.
+  # default_unique_key_fields:
   #   - "_bkt"
   #   - "_cd"
 
@@ -64,7 +64,7 @@ instances:
         # initial_history_time_seconds: 0
         # max_restart_history_seconds: 86400
         # max_query_chunk_seconds: 3600
-        # fields_for_identification:
+        # unique_key_fields:
         #   - "_bkt"
         #   - "_cd"
 

--- a/conf.d/splunk_metric.yaml.example
+++ b/conf.d/splunk_metric.yaml.example
@@ -35,6 +35,11 @@ init_config:
   # The metric value field should contain numerical data in the splunk results
   # default_metric_value_field: "value"
 
+  # Fields to uniquely identify a record. Use fields_for_identification: None to use the whole record.
+  # default_fields_for_identification:
+  #   - "_bkt"
+  #   - "_cd"
+
 # Currently it is not possible to specify multiple instances with the same url.
 # It is possible to specify multiple saved_searches on a single instance.
 instances:
@@ -59,6 +64,9 @@ instances:
         # initial_history_time_seconds: 0
         # max_restart_history_seconds: 86400
         # max_query_chunk_seconds: 3600
+        # fields_for_identification:
+        #   - "_bkt"
+        #   - "_cd"
 
         # Additional parameters for the splunk saved search query
         parameters:

--- a/tests/checks/fixtures/splunk_event/identification_fields_all_events.json
+++ b/tests/checks/fixtures/splunk_event/identification_fields_all_events.json
@@ -1,0 +1,22 @@
+{
+	"preview": false,
+	"init_offset": 0,
+	"messages": [],
+	"fields": [{
+		"name": "event_type"
+	}, {
+		"name": "value"
+	}, {
+		"name": "_time"
+	}],
+	"results": [{
+		"event_type": "some_type",
+		"value": 1,
+		"_time": "2018-12-08T18:29:56.000+00:00"
+	}, {
+		"event_type": "some_type",
+		"value": 2,
+		"_time": "2018-12-08T18:29:56.000+00:00"
+	}],
+	"highlighted": {}
+}

--- a/tests/checks/fixtures/splunk_event/identification_fields_selective_events.json
+++ b/tests/checks/fixtures/splunk_event/identification_fields_selective_events.json
@@ -1,0 +1,26 @@
+{
+	"preview": false,
+	"init_offset": 0,
+	"messages": [],
+	"fields": [{
+		"name": "event_type"
+	}, {
+		"name": "uid1"
+	}, {
+		"name": "uid2"
+	}, {
+		"name": "_time"
+	}],
+	"results": [{
+		"event_type": "some_type",
+		"uid1": "uid",
+		"uid2": 1,
+		"_time": "2018-12-08T18:29:56.000+00:00"
+	}, {
+		"event_type": "some_type",
+		"uid1": "uid",
+		"uid2": 2,
+		"_time": "2018-12-08T18:29:56.000+00:00"
+	}],
+	"highlighted": {}
+}

--- a/tests/checks/fixtures/splunk_metric/metrics_identification_fields_all.json
+++ b/tests/checks/fixtures/splunk_metric/metrics_identification_fields_all.json
@@ -1,0 +1,16 @@
+{
+	"preview": false,
+	"init_offset": 0,
+	"messages": [],
+	"fields": [],
+	"results": [{
+		"_time": "2017-12-18T12:00:00.000+00:00",
+        "value": 1,
+        "metric": "metric_name"
+	}, {
+		"_time": "2017-12-18T12:00:00.000+00:00",
+        "value": 2,
+        "metric": "metric_name"
+	}],
+	"highlighted": {}
+}

--- a/tests/checks/fixtures/splunk_metric/metrics_identification_fields_selective.json
+++ b/tests/checks/fixtures/splunk_metric/metrics_identification_fields_selective.json
@@ -1,0 +1,20 @@
+{
+	"preview": false,
+	"init_offset": 0,
+	"messages": [],
+	"fields": [],
+	"results": [{
+		"_time": "2017-12-18T12:00:00.000+00:00",
+        "uid1": "uid",
+		"uid2": 1,
+        "value": 1,
+        "metric": "metric_name"
+	}, {
+		"_time": "2017-12-18T12:00:00.000+00:00",
+		"uid1": "uid",
+		"uid2": 2,
+        "value": 2,
+        "metric": "metric_name"
+	}],
+	"highlighted": {}
+}

--- a/tests/checks/mock/test_splunk_event.py
+++ b/tests/checks/mock/test_splunk_event.py
@@ -934,7 +934,7 @@ class TestSplunkSelectiveFieldsForIdentification(AgentCheckTest):
                     'saved_searches': [{
                         "name": "selective_events",
                         "parameters": {},
-                        "fields_for_identification": ["uid1", "uid2"]
+                        "unique_key_fields": ["uid1", "uid2"]
                     }],
                     'tags': []
                 }
@@ -993,7 +993,7 @@ class TestSplunkAllFieldsForIdentification(AgentCheckTest):
                     'saved_searches': [{
                         "name": "all_events",
                         "parameters": {},
-                        "fields_for_identification": []
+                        "unique_key_fields": []
                     }],
                     'tags': []
                 }

--- a/tests/checks/mock/test_splunk_event.py
+++ b/tests/checks/mock/test_splunk_event.py
@@ -993,7 +993,7 @@ class TestSplunkAllFieldsForIdentification(AgentCheckTest):
                     'saved_searches': [{
                         "name": "all_events",
                         "parameters": {},
-                        "fields_for_identification": None
+                        "fields_for_identification": []
                     }],
                     'tags': []
                 }

--- a/tests/checks/mock/test_splunk_event.py
+++ b/tests/checks/mock/test_splunk_event.py
@@ -866,6 +866,10 @@ def _mocked_full_search(*args, **kwargs):
     sid = args[0]
     return [json.loads(Fixtures.read_file("full_%s.json" % sid))]
 
+def _mocked_identification_fields_search(*args, **kwargs):
+    # sid is set to saved search name
+    sid = args[0]
+    return [json.loads(Fixtures.read_file("identification_fields_%s.json" % sid))]
 
 class TestSplunkEventRespectParallelDispatches(AgentCheckTest):
     CHECK_NAME = 'splunk_event'
@@ -909,3 +913,121 @@ class TestSplunkEventRespectParallelDispatches(AgentCheckTest):
             '_dispatch_and_await_search': _mock_dispatch_and_await_search,
             '_saved_searches': _mocked_saved_searches
         })
+
+
+class TestSplunkSelectiveFieldsForIdentification(AgentCheckTest):
+    """
+    Splunk event check should process events where the unique identifier is set to a selective number of fields
+    """
+    CHECK_NAME = 'splunk_event'
+
+    def test_checks(self):
+        self.maxDiff = None
+
+        config = {
+            'init_config': {},
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "selective_events",
+                        "parameters": {},
+                        "fields_for_identification": ["uid1", "uid2"]
+                    }],
+                    'tags': []
+                }
+            ]
+        }
+
+        self.run_check(config, mocks={
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_identification_fields_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.events), 2)
+        self.assertEqual(self.events[0], {
+            'event_type': u"some_type",
+            'tags': [u"uid2:1", u"uid1:uid"],
+            'timestamp': 1544293796.0,
+            'msg_title': None,
+            'msg_text': None,
+            'source_type_name': None
+        })
+        self.assertEqual(self.events[1], {
+            'event_type': u"some_type",
+            'tags': [u"uid2:2", u"uid1:uid"],
+            'timestamp': 1544293796.0,
+            'msg_title': None,
+            'msg_text': None,
+            'source_type_name': None
+        })
+
+        # shouldn't resend events
+        self.run_check(config, mocks={
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_identification_fields_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+        self.assertEqual(len(self.events), 0)
+
+
+class TestSplunkAllFieldsForIdentification(AgentCheckTest):
+    """
+    Splunk event check should process events where the unique identifier is set to all fields in a record
+    """
+    CHECK_NAME = 'splunk_event'
+
+    def test_checks(self):
+        self.maxDiff = None
+
+        config = {
+            'init_config': {},
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "all_events",
+                        "parameters": {},
+                        "fields_for_identification": None
+                    }],
+                    'tags': []
+                }
+            ]
+        }
+
+        self.run_check(config, mocks={
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_identification_fields_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.events), 2)
+        self.assertEqual(self.events[0], {
+            'event_type': u"some_type",
+            'tags': [u"value:1"],
+            'timestamp': 1544293796.0,
+            'msg_title': None,
+            'msg_text': None,
+            'source_type_name': None
+        })
+        self.assertEqual(self.events[1], {
+            'event_type': u"some_type",
+            'tags': [u"value:2"],
+            'timestamp': 1544293796.0,
+            'msg_title': None,
+            'msg_text': None,
+            'source_type_name': None
+        })
+
+        # shouldn't resend events
+        self.run_check(config, mocks={
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_identification_fields_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+        self.assertEqual(len(self.events), 0)

--- a/tests/checks/mock/test_splunk_metric.py
+++ b/tests/checks/mock/test_splunk_metric.py
@@ -988,3 +988,111 @@ class TestSplunkMetricRespectParallelDispatches(AgentCheckTest):
             '_dispatch_and_await_search': _mock_dispatch_and_await_search,
             '_saved_searches': _mocked_saved_searches
         })
+
+class TestSplunkSelectiveFieldsForIdentification(AgentCheckTest):
+    """
+    Splunk metrics check should process metrics where the unique identifier is set to a selective number of fields
+    """
+    CHECK_NAME = 'splunk_metric'
+
+    def test_checks(self):
+        self.maxDiff = None
+
+        config = {
+            'init_config': {},
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "metrics_identification_fields_selective",
+                        "parameters": {},
+                        "fields_for_identification": ["uid1", "uid2"]
+                    }],
+                    'tags': []
+                }
+            ]
+        }
+
+        self.run_check(config, mocks={
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.metrics), 2)
+        self.assertMetric(
+            'metric_name',
+            time=1513598400.0,
+            value=1,
+            tags=["uid1:uid", "uid2:1"])
+        self.assertMetric(
+            'metric_name',
+            time=1513598400.0,
+            value=2,
+            tags=["uid1:uid", "uid2:2"])
+
+        # shouldn't resend the metrics
+        self.run_check(config, mocks={
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.metrics), 0)
+
+
+class TestSplunkAllFieldsForIdentification(AgentCheckTest):
+    """
+    Splunk metrics check should process metrics where the unique identifier is set to all fields in a record
+    """
+    CHECK_NAME = 'splunk_metric'
+
+    def test_checks(self):
+        self.maxDiff = None
+
+        config = {
+            'init_config': {},
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "metrics_identification_fields_all",
+                        "parameters": {},
+                        "fields_for_identification": None
+                    }],
+                    'tags': []
+                }
+            ]
+        }
+
+        self.run_check(config, mocks={
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.metrics), 2)
+        self.assertMetric(
+            'metric_name',
+            time=1513598400.0,
+            value=1,
+            tags=[])
+        self.assertMetric(
+            'metric_name',
+            time=1513598400.0,
+            value=2,
+            tags=[])
+
+
+        # shouldn't resend the metrics
+        self.run_check(config, mocks={
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.metrics), 0)

--- a/tests/checks/mock/test_splunk_metric.py
+++ b/tests/checks/mock/test_splunk_metric.py
@@ -1062,7 +1062,7 @@ class TestSplunkAllFieldsForIdentification(AgentCheckTest):
                     'saved_searches': [{
                         "name": "metrics_identification_fields_all",
                         "parameters": {},
-                        "fields_for_identification": None
+                        "fields_for_identification": []
                     }],
                     'tags': []
                 }

--- a/tests/checks/mock/test_splunk_metric.py
+++ b/tests/checks/mock/test_splunk_metric.py
@@ -1008,7 +1008,7 @@ class TestSplunkSelectiveFieldsForIdentification(AgentCheckTest):
                     'saved_searches': [{
                         "name": "metrics_identification_fields_selective",
                         "parameters": {},
-                        "fields_for_identification": ["uid1", "uid2"]
+                        "unique_key_fields": ["uid1", "uid2"]
                     }],
                     'tags': []
                 }
@@ -1062,7 +1062,7 @@ class TestSplunkAllFieldsForIdentification(AgentCheckTest):
                     'saved_searches': [{
                         "name": "metrics_identification_fields_all",
                         "parameters": {},
-                        "fields_for_identification": []
+                        "unique_key_fields": []
                     }],
                     'tags': []
                 }

--- a/tests/core/test_utils_splunk.py
+++ b/tests/core/test_utils_splunk.py
@@ -22,7 +22,8 @@ class TestUtilsSplunk(TestCase):
             'default_search_seconds_between_retries': 1,
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
-            'default_saved_searches_parallel': 3
+            'default_saved_searches_parallel': 3,
+            'default_fields_for_identification': ["_bkt", "_cd"]
         })
         saved_search = SplunkSavedSearch(instance_config, {"name": "search", "parameters": {}})
 
@@ -54,7 +55,8 @@ class TestUtilsSplunk(TestCase):
             'default_search_seconds_between_retries': 1,
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
-            'default_saved_searches_parallel': 3
+            'default_saved_searches_parallel': 3,
+            'default_fields_for_identification': ["_bkt", "_cd"]
         })
 
         def _mocked_do_get(*args, **kwargs):
@@ -93,7 +95,8 @@ class TestSavedSearches(TestCase):
             'default_search_seconds_between_retries': 1,
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
-            'default_saved_searches_parallel': 3
+            'default_saved_searches_parallel': 3,
+            'default_fields_for_identification': ["_bkt", "_cd"]
         })
 
         saved_search_components = SplunkSavedSearch(instance_config, {"name": "components", "parameters": {}})

--- a/tests/core/test_utils_splunk.py
+++ b/tests/core/test_utils_splunk.py
@@ -23,7 +23,7 @@ class TestUtilsSplunk(TestCase):
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
-            'default_fields_for_identification': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"]
         })
         saved_search = SplunkSavedSearch(instance_config, {"name": "search", "parameters": {}})
 
@@ -56,7 +56,7 @@ class TestUtilsSplunk(TestCase):
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
-            'default_fields_for_identification': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"]
         })
 
         def _mocked_do_get(*args, **kwargs):
@@ -96,7 +96,7 @@ class TestSavedSearches(TestCase):
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
-            'default_fields_for_identification': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"]
         })
 
         saved_search_components = SplunkSavedSearch(instance_config, {"name": "components", "parameters": {}})

--- a/utils/splunk/splunk.py
+++ b/utils/splunk/splunk.py
@@ -30,7 +30,6 @@ class SplunkSavedSearch(object):
         self.search_max_retry_count = int(saved_search_instance.get('search_max_retry_count', instance_config.default_search_max_retry_count))
         self.search_seconds_between_retries = int(saved_search_instance.get('search_seconds_between_retries', instance_config.default_search_seconds_between_retries))
         self.batch_size = int(saved_search_instance.get('batch_size', instance_config.default_batch_size))
-        self.fields_for_identification = saved_search_instance.get('fields_for_identification', instance_config.default_fields_for_identification)
 
     def retrieve_fields(self, data):
         telemetry = {}
@@ -77,7 +76,6 @@ class SplunkInstanceConfig(object):
         self.default_verify_ssl_certificate = self.get_or_default('default_verify_ssl_certificate')
         self.default_batch_size = self.get_or_default('default_batch_size')
         self.default_saved_searches_parallel = self.get_or_default('default_saved_searches_parallel')
-        self.default_fields_for_identification = self.get_or_default('default_fields_for_identification')
 
         self.verify_ssl_certificate = bool(instance.get('verify_ssl_certificate', self.default_verify_ssl_certificate))
         self.base_url = instance['url']
@@ -89,6 +87,13 @@ class SplunkInstanceConfig(object):
 
     def get_auth_tuple(self):
         return self.username, self.password
+
+
+class SplunkTelemetryInstanceConfig(SplunkInstanceConfig):
+    def __init__(self, instance, init_config, defaults):
+        super(SplunkTelemetryInstanceConfig, self).__init__(instance, init_config, defaults)
+
+        self.default_fields_for_identification = self.get_or_default('default_fields_for_identification')
 
 
 class SavedSearches(object):

--- a/utils/splunk/splunk.py
+++ b/utils/splunk/splunk.py
@@ -93,7 +93,7 @@ class SplunkTelemetryInstanceConfig(SplunkInstanceConfig):
     def __init__(self, instance, init_config, defaults):
         super(SplunkTelemetryInstanceConfig, self).__init__(instance, init_config, defaults)
 
-        self.default_fields_for_identification = self.get_or_default('default_fields_for_identification')
+        self.default_unique_key_fields = self.get_or_default('default_unique_key_fields')
 
 
 class SavedSearches(object):

--- a/utils/splunk/splunk.py
+++ b/utils/splunk/splunk.py
@@ -30,6 +30,7 @@ class SplunkSavedSearch(object):
         self.search_max_retry_count = int(saved_search_instance.get('search_max_retry_count', instance_config.default_search_max_retry_count))
         self.search_seconds_between_retries = int(saved_search_instance.get('search_seconds_between_retries', instance_config.default_search_seconds_between_retries))
         self.batch_size = int(saved_search_instance.get('batch_size', instance_config.default_batch_size))
+        self.fields_for_identification = saved_search_instance.get('fields_for_identification', instance_config.default_fields_for_identification)
 
     def retrieve_fields(self, data):
         telemetry = {}
@@ -76,6 +77,7 @@ class SplunkInstanceConfig(object):
         self.default_verify_ssl_certificate = self.get_or_default('default_verify_ssl_certificate')
         self.default_batch_size = self.get_or_default('default_batch_size')
         self.default_saved_searches_parallel = self.get_or_default('default_saved_searches_parallel')
+        self.default_fields_for_identification = self.get_or_default('default_fields_for_identification')
 
         self.verify_ssl_certificate = bool(instance.get('verify_ssl_certificate', self.default_verify_ssl_certificate))
         self.base_url = instance['url']

--- a/utils/splunk/splunk_telemetry.py
+++ b/utils/splunk/splunk_telemetry.py
@@ -7,6 +7,8 @@ class SplunkTelemetrySavedSearch(SplunkSavedSearch):
     def __init__(self, instance_config, saved_search_instance):
         super(SplunkTelemetrySavedSearch, self).__init__(instance_config, saved_search_instance)
 
+        self.fields_for_identification = saved_search_instance.get('fields_for_identification', instance_config.default_fields_for_identification)
+
         self.config = {
             field_name: saved_search_instance.get(field_name, instance_config.get_or_default("default_" + field_name))
             for field_name in ['initial_history_time_seconds', 'max_restart_history_seconds', 'max_query_chunk_seconds']

--- a/utils/splunk/splunk_telemetry.py
+++ b/utils/splunk/splunk_telemetry.py
@@ -43,13 +43,11 @@ class SplunkTelemetryInstance(object):
             instance['saved_searches'] = []
 
         self.saved_searches = saved_searches
-
         self.saved_searches_parallel = int(instance.get('saved_searches_parallel', self.instance_config.get_or_default('default_saved_searches_parallel')))
-
         self.tags = instance.get('tags', [])
         self.initial_delay_seconds = int(instance.get('initial_delay_seconds', self.instance_config.get_or_default('default_initial_delay_seconds')))
-
         self.launch_time_seconds = current_time
+        self.fields_for_identification = instance.get('fields_for_identification', self.instance_config.get_or_default('default_fields_for_identification'))
 
     def initial_time_done(self, current_time_seconds):
         return current_time_seconds >= self.launch_time_seconds + self.initial_delay_seconds

--- a/utils/splunk/splunk_telemetry.py
+++ b/utils/splunk/splunk_telemetry.py
@@ -7,7 +7,7 @@ class SplunkTelemetrySavedSearch(SplunkSavedSearch):
     def __init__(self, instance_config, saved_search_instance):
         super(SplunkTelemetrySavedSearch, self).__init__(instance_config, saved_search_instance)
 
-        self.fields_for_identification = saved_search_instance.get('fields_for_identification', instance_config.default_fields_for_identification)
+        self.unique_key_fields = saved_search_instance.get('unique_key_fields', instance_config.default_unique_key_fields)
 
         self.config = {
             field_name: saved_search_instance.get(field_name, instance_config.get_or_default("default_" + field_name))
@@ -49,7 +49,7 @@ class SplunkTelemetryInstance(object):
         self.tags = instance.get('tags', [])
         self.initial_delay_seconds = int(instance.get('initial_delay_seconds', self.instance_config.get_or_default('default_initial_delay_seconds')))
         self.launch_time_seconds = current_time
-        self.fields_for_identification = instance.get('fields_for_identification', self.instance_config.get_or_default('default_fields_for_identification'))
+        self.unique_key_fields = instance.get('unique_key_fields', self.instance_config.get_or_default('default_unique_key_fields'))
 
     def initial_time_done(self, current_time_seconds):
         return current_time_seconds >= self.launch_time_seconds + self.initial_delay_seconds

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -89,7 +89,7 @@ class SplunkTelemetryBase(AgentCheck):
             # We need a unique identifier for splunk events, according to https://answers.splunk.com/answers/334613/is-there-a-unique-event-id-for-each-event-in-the-i.html
             # this can be (server, index, _cd)
 
-            if saved_search.fields_for_identification is None: # whole record
+            if not saved_search.fields_for_identification: # empty list, whole record
                 current_id = tuple(data)
             else:
                 current_id = tuple(data[field] for field in saved_search.fields_for_identification)

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -88,8 +88,12 @@ class SplunkTelemetryBase(AgentCheck):
         for data in result["results"]:
             # We need a unique identifier for splunk events, according to https://answers.splunk.com/answers/334613/is-there-a-unique-event-id-for-each-event-in-the-i.html
             # this can be (server, index, _cd)
-            # I use (_bkt, _cd) because we only process data from 1 server in a check, and _bkt contains the index
-            current_id = (data["_bkt"], data["_cd"])
+
+            if saved_search.fields_for_identification is None: # whole record
+                current_id = tuple(data)
+            else:
+                current_id = tuple(data[field] for field in saved_search.fields_for_identification)
+
             timestamp = time_to_seconds(take_required_field("_time", data))
 
             if timestamp > saved_search.last_observed_timestamp:

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -89,10 +89,10 @@ class SplunkTelemetryBase(AgentCheck):
             # We need a unique identifier for splunk events, according to https://answers.splunk.com/answers/334613/is-there-a-unique-event-id-for-each-event-in-the-i.html
             # this can be (server, index, _cd)
 
-            if not saved_search.fields_for_identification: # empty list, whole record
+            if not saved_search.unique_key_fields:  # empty list, whole record
                 current_id = tuple(data)
             else:
-                current_id = tuple(data[field] for field in saved_search.fields_for_identification)
+                current_id = tuple(data[field] for field in saved_search.unique_key_fields)
 
             timestamp = time_to_seconds(take_required_field("_time", data))
 


### PR DESCRIPTION
Previously the Splunk event and metric checks would identify records solely on `_bkt` and `_cd` fields for deduplication purposes. This PR introduces a setting, `fields_for_identification`, that let's the check's user specify which fields make a record unique, per saved search. Setting `fields_for_identification` to `[]` results in using the whole record for identification.

The default behaviour contains fields `_bkt` and `_cd`.