### PR TITLE
changing defaults to ones that based on measurements

### DIFF
--- a/connbeat.yml
+++ b/connbeat.yml
@@ -2,8 +2,8 @@ connbeat:
   expose_process_info: true
   expose_cmdline: true
   expose_environ: false
-  aggregation: 10s
-  poll_interval: 2s
+  aggregation: 60s
+  poll_interval: 10s
   enable_tcp_diag: false
   enable_local_connections: true
   enable_docker: false


### PR DESCRIPTION
Based on performance measurements below:

default config (environment disabled), no applicatins running only os processes       15 kb per minute
default config (environment disabled), 1000 clients vs 1000 servers        			  750 kb per minute
default config (environment disabled), aggregation 60s, polling 10s        1000 clients vs 1000 servers, 250 kb per minute
default config (environment disabled), aggregation 120s, polling 10s       1000 clients vs 1000 servers, 213 kb per minute
default config (environment disabled), aggregation 180s, polling 10s       1000 clients vs 1000 servers, 151 kb per minute
default config (environment disabled), aggregation 600s, polling 10s       1000 clients vs 1000 servers, 100 kb per minute	




























