### PR TITLE
Reduce the number of Splunk API logins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   only:
     - master
     - /^\d+\.\d+\.x$/ # release forked patches branch
-    - splunk_reduce_logins
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - master
     - /^\d+\.\d+\.x$/ # release forked patches branch
+    - splunk_reduce_logins
 
 language: python
 python:

--- a/tests/core/test_splunk_helper.py
+++ b/tests/core/test_splunk_helper.py
@@ -1,0 +1,75 @@
+# stdlib
+import unittest
+
+# 3p
+import mock
+import json
+
+# project
+from utils.splunk.splunk_helper import SplunkHelper
+
+
+class FakeInstanceConfig(object):
+    def __init__(self):
+        self.base_url = 'http://testhost:8089'
+        self.default_request_timeout_seconds = 10
+        self.verify_ssl_certificate = False
+        self.auth_session_key = None
+
+    def get_auth_tuple(self):
+        return ('username', 'password')
+
+    def set_auth_session_key(self, session_key):
+        self.auth_session_key = session_key
+
+    def get_auth_session_key(self):
+        return self.auth_session_key
+
+
+class FakeResponse(object):
+    def __init__(self, text, status_code=200):
+        self.status_code = status_code
+        self.payload = text
+
+    def json(self):
+        return json.loads(self.payload)
+
+    def raise_for_status(self):
+        return None
+
+
+class TestSplunkHelper(unittest.TestCase):
+    """
+    Test the Splunk Helper class
+    """
+
+    @mock.patch('utils.splunk.splunk_helper.SplunkHelper.do_post', return_value=FakeResponse("""{ "sessionKey": "MySessionKeyForThisSession" }"""))
+    def test_auth_session(self, mocked_do_post):
+        """
+        retrieve auth session key
+        """
+        helper = SplunkHelper()
+        auth_session_key = helper.auth_session(FakeInstanceConfig())
+
+        mocked_do_post.assert_called_with("http://testhost:8089/services/auth/login?output_mode=json", "", "username=username&password=password", 10, False)
+        mocked_do_post.assert_called_once()
+
+        self.assertEqual(auth_session_key, "MySessionKeyForThisSession")
+
+    @mock.patch('utils.splunk.splunk_helper.SplunkHelper._do_get')
+    def test_saved_search_can_obtain_auth_session_key(self, mocked_do_get):
+        def _do_get(*args):
+            self.assertEqual(args[1], "MySessionKey")
+            return FakeResponse("""{"entry": [{"name": "name"}]}""")
+
+        mocked_do_get.side_effect = _do_get
+
+        helper = SplunkHelper()
+        instance_config = FakeInstanceConfig()
+        instance_config.set_auth_session_key("MySessionKey")
+
+        instance_config.get_auth_session_key = mock.MagicMock(return_value="MySessionKey")
+
+        helper.saved_searches(instance_config)
+
+        instance_config.get_auth_session_key.assert_called_once()

--- a/utils/splunk/splunk.py
+++ b/utils/splunk/splunk.py
@@ -81,12 +81,19 @@ class SplunkInstanceConfig(object):
         self.base_url = instance['url']
         self.username = instance['username']
         self.password = instance['password']
+        self.auth_session_key = None
 
     def get_or_default(self, field):
         return self.init_config.get(field, self.defaults[field])
 
     def get_auth_tuple(self):
         return self.username, self.password
+
+    def set_auth_session_key(self, session_key):
+        self.auth_session_key = session_key
+
+    def get_auth_session_key(self):
+        return self.auth_session_key
 
 
 class SplunkTelemetryInstanceConfig(SplunkInstanceConfig):

--- a/utils/splunk/splunk_helper.py
+++ b/utils/splunk/splunk_helper.py
@@ -96,8 +96,6 @@ class SplunkHelper(object):
         return response
 
     def do_post(self, url, auth_session_key, payload, request_timeout_seconds, verify_ssl_certificate):
-        self.log.info("url %s" % url)
-        self.log.info("auth_session " + auth_session_key)
         headers = {
             'Content-Type': 'application/x-www-form-urlencoded',
             'Authorization': 'Splunk %s' % auth_session_key

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -41,7 +41,7 @@ class SplunkTelemetryBase(AgentCheck):
         instance.update_status(current_time, self.status)
 
         try:
-            instance.instance_config.set_auth_session_key(self.splunkHelper.auth_session(instance.instance_config))
+            instance.instance_config.set_auth_session_key(self._auth_session(instance.instance_config))
 
             saved_searches = self._saved_searches(instance.instance_config)
             instance.saved_searches.update_searches(self.log, saved_searches)
@@ -185,6 +185,10 @@ class SplunkTelemetryBase(AgentCheck):
 
         response_body = self._do_post(dispatch_url, auth_session_key, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
         return response_body['sid']
+
+    def _auth_session(self, instance_config):
+        """ This method is mocked for testing. Do not change its behavior """
+        return self.splunkHelper.auth_session(instance_config)
 
     def _do_post(self, url, auth_session_key, payload, timeout, verify_ssl):
         """ This method is mocked for testing. Do not change its behavior """

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -41,6 +41,8 @@ class SplunkTelemetryBase(AgentCheck):
         instance.update_status(current_time, self.status)
 
         try:
+            instance.instance_config.set_auth_session_key(self.splunkHelper.auth_session(instance.instance_config))
+
             saved_searches = self._saved_searches(instance.instance_config)
             instance.saved_searches.update_searches(self.log, saved_searches)
 
@@ -151,7 +153,7 @@ class SplunkTelemetryBase(AgentCheck):
         :return:
         """
         dispatch_url = '%s/services/saved/searches/%s/dispatch' % (instance_config.base_url, quote(saved_search.name))
-        auth = instance_config.get_auth_tuple()
+        auth_session_key = instance_config.get_auth_session_key()
 
         parameters = saved_search.parameters
         # json output_mode is mandatory for response parsing
@@ -181,12 +183,12 @@ class SplunkTelemetryBase(AgentCheck):
 
         self.log.debug("Dispatching saved search: %s starting at %s." % (saved_search.name, parameters["dispatch.earliest_time"]))
 
-        response_body = self._do_post(dispatch_url, auth, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
+        response_body = self._do_post(dispatch_url, auth_session_key, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
         return response_body['sid']
 
-    def _do_post(self, url, auth, payload, timeout, verify_ssl):
+    def _do_post(self, url, auth_session_key, payload, timeout, verify_ssl):
         """ This method is mocked for testing. Do not change its behavior """
-        return self.splunkHelper.do_post(url, auth, payload, timeout, verify_ssl)
+        return self.splunkHelper.do_post(url, auth_session_key, payload, timeout, verify_ssl)
 
     def _saved_searches(self, instance_config):
         """ This method is mocked for testing. Do not change its behavior """


### PR DESCRIPTION
For each Splunk API request a login using http basic auth was made. A combination of multiple, larger, saved searches across topology and telemetry checks spikes the number of logins.

Splunk's API supports a session key. This PR implements a log in once per check run and using the session key in subsequent requests.

Fix for STAC-1986