### PR TITLE
Splunk authentication based on requests session

### DIFF
--- a/tests/core/test_splunk_helper.py
+++ b/tests/core/test_splunk_helper.py
@@ -14,28 +14,22 @@ class FakeInstanceConfig(object):
         self.base_url = 'http://testhost:8089'
         self.default_request_timeout_seconds = 10
         self.verify_ssl_certificate = False
-        self.auth_session_key = None
 
     def get_auth_tuple(self):
         return ('username', 'password')
 
-    def set_auth_session_key(self, session_key):
-        self.auth_session_key = session_key
-
-    def get_auth_session_key(self):
-        return self.auth_session_key
-
 
 class FakeResponse(object):
-    def __init__(self, text, status_code=200):
+    def __init__(self, text, status_code=200, headers={}):
         self.status_code = status_code
         self.payload = text
+        self.headers = headers
 
     def json(self):
         return json.loads(self.payload)
 
     def raise_for_status(self):
-        return None
+        return
 
 
 class TestSplunkHelper(unittest.TestCase):
@@ -43,33 +37,44 @@ class TestSplunkHelper(unittest.TestCase):
     Test the Splunk Helper class
     """
 
-    @mock.patch('utils.splunk.splunk_helper.SplunkHelper.do_post', return_value=FakeResponse("""{ "sessionKey": "MySessionKeyForThisSession" }"""))
+    @mock.patch('utils.splunk.splunk_helper.SplunkHelper.do_post',
+                return_value=FakeResponse(text="""{"sessionKey": "MySessionKeyForThisSession"}""",
+                                          headers={"Set-Cookie": "Set-Cookie: splunkd_8089=MySessionKeyForThisSession; Path=/; Secure; HttpOnly; Max-Age=3600; Expires=Mon, 09 Apr 2018 15:09:54 GMT"}))
     def test_auth_session(self, mocked_do_post):
         """
-        retrieve auth session key
+        Test request authentication based on Cookie
+        retrieve auth session key,
+        set it to the requests session,
+        and see whether the outgoing request contains the expected HTTP header.
+        The expected HTTP header is Set-Cookie.
         """
         helper = SplunkHelper()
-        auth_session_key = helper.auth_session(FakeInstanceConfig())
+        helper.auth_session(FakeInstanceConfig())
 
-        mocked_do_post.assert_called_with("http://testhost:8089/services/auth/login?output_mode=json", "", "username=username&password=password", 10, False)
+        mocked_do_post.assert_called_with("http://testhost:8089/services/auth/login?output_mode=json", "username=username&password=password&cookie=1", 10, False)
         mocked_do_post.assert_called_once()
 
-        self.assertEqual(auth_session_key, "MySessionKeyForThisSession")
+        header = helper.requests_session.headers.get("Set-Cookie")
+        self.assertTrue(header.startswith("Set-Cookie: splunkd_8089"))
+        header.index("MySessionKeyForThisSession")
 
-    @mock.patch('utils.splunk.splunk_helper.SplunkHelper._do_get')
-    def test_saved_search_can_obtain_auth_session_key(self, mocked_do_get):
-        def _do_get(*args):
-            self.assertEqual(args[1], "MySessionKey")
-            return FakeResponse("""{"entry": [{"name": "name"}]}""")
+        # don't expect the Authentication header
+        self.assertFalse(helper.requests_session.headers.get("Authentication", False))
 
-        mocked_do_get.side_effect = _do_get
-
+    @mock.patch('utils.splunk.splunk_helper.SplunkHelper.do_post', return_value=FakeResponse("""{ "sessionKey": "MySessionKeyForThisSession" }""", headers={}))
+    def test_auth_session_fallback(self, mocked_do_post):
+        """
+        Test request authentication on fallback Authentication header
+        retrieve auth session key,
+        set it to the requests session,
+        and see whether the outgoing request contains the expected HTTP header
+        The expected HTTP header is Authentication when Set-Cookie is not present
+        """
         helper = SplunkHelper()
-        instance_config = FakeInstanceConfig()
-        instance_config.set_auth_session_key("MySessionKey")
+        helper.auth_session(FakeInstanceConfig())
 
-        instance_config.get_auth_session_key = mock.MagicMock(return_value="MySessionKey")
+        mocked_do_post.assert_called_with("http://testhost:8089/services/auth/login?output_mode=json", "username=username&password=password&cookie=1", 10, False)
+        mocked_do_post.assert_called_once()
 
-        helper.saved_searches(instance_config)
-
-        instance_config.get_auth_session_key.assert_called_once()
+        expected_header = helper.requests_session.headers.get("Authentication")
+        self.assertEqual(expected_header, "Splunk MySessionKeyForThisSession")

--- a/utils/splunk/splunk.py
+++ b/utils/splunk/splunk.py
@@ -81,19 +81,12 @@ class SplunkInstanceConfig(object):
         self.base_url = instance['url']
         self.username = instance['username']
         self.password = instance['password']
-        self.auth_session_key = None
 
     def get_or_default(self, field):
         return self.init_config.get(field, self.defaults[field])
 
     def get_auth_tuple(self):
         return self.username, self.password
-
-    def set_auth_session_key(self, session_key):
-        self.auth_session_key = session_key
-
-    def get_auth_session_key(self):
-        return self.auth_session_key
 
 
 class SplunkTelemetryInstanceConfig(SplunkInstanceConfig):

--- a/utils/splunk/splunk_helper.py
+++ b/utils/splunk/splunk_helper.py
@@ -14,23 +14,31 @@ class SplunkHelper(object):
 
     def __init__(self):
         self.log = logging.getLogger('%s' % __name__)
+        self.requests_session = requests.session()
 
     def auth_session(self, instance_config):
         """
         retrieves a session token from Splunk to be used in subsequent requests
         session key expires after default 1 hour, configurable in Splunk: Settings -> Server -> General -> Session timeout
         Splunk returns the same key for the username/password combination.
+        Side affecting function.
         An expired key results in a 401 Unauthorized response with content:
           {"messages":[{"type":"WARN","text":"call not properly authenticated"}]}%
         :param instance_config: InstanceConfig, current check configuration
-        :return: session key, string
+        :return: nothing
         """
         auth_url = '%s/services/auth/login?output_mode=json' % instance_config.base_url
         auth_username, auth_password = instance_config.get_auth_tuple()
         payload = urlencode({'username': auth_username, 'password': auth_password, 'cookie': 1})
-        response = self.do_post(auth_url, "", payload, instance_config.default_request_timeout_seconds, instance_config.verify_ssl_certificate).json()
-        session_key = response["sessionKey"]
-        return session_key
+        response = self.do_post(auth_url, payload, instance_config.default_request_timeout_seconds, instance_config.verify_ssl_certificate)
+        response.raise_for_status()
+        response_json = response.json()
+
+        if 'Set-Cookie' in response.headers:
+            self.requests_session.headers.update({'Set-Cookie': response.headers['Set-Cookie']})
+        else:  # fallback to header, ref: http://docs.splunk.com/Documentation/Splunk/7.0.3/RESTREF/RESTaccess
+            session_key = response_json["sessionKey"]
+            self.requests_session.headers.update({'Authentication': "Splunk %s" % session_key})
 
     def saved_searches(self, instance_config):
         """
@@ -39,9 +47,7 @@ class SplunkHelper(object):
         :return: list of names of saved searches
         """
         search_url = '%s/services/saved/searches?output_mode=json&count=-1' % instance_config.base_url
-        auth_session_key = instance_config.get_auth_session_key()
-
-        response = self._do_get(search_url, auth_session_key, instance_config.default_request_timeout_seconds, instance_config.verify_ssl_certificate)
+        response = self._do_get(search_url, instance_config.default_request_timeout_seconds, instance_config.verify_ssl_certificate)
         return [entry["name"] for entry in response.json()["entry"]]
 
     def _search_chunk(self, instance_config, saved_search, search_id, offset, count):
@@ -55,8 +61,7 @@ class SplunkHelper(object):
         :return: raw json response from splunk
         """
         search_url = '%s/services/search/jobs/%s/results?output_mode=json&offset=%s&count=%s' % (instance_config.base_url, search_id, offset, count)
-        auth_session_key = instance_config.get_auth_session_key()
-        response = self._do_get(search_url, auth_session_key, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate)
+        response = self._do_get(search_url, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate)
         retry_count = 0
 
         # retry until information is available.
@@ -65,7 +70,7 @@ class SplunkHelper(object):
                 raise CheckException("maximum retries reached for " + instance_config.base_url + " with search id " + search_id)
             retry_count += 1
             time.sleep(saved_search.search_seconds_between_retries)
-            response = self._do_get(search_url, auth_session_key, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate)
+            response = self._do_get(search_url, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate)
 
         return response.json()
 
@@ -89,18 +94,16 @@ class SplunkHelper(object):
             offset += nr_of_results
         return results
 
-    def _do_get(self, url, auth_session_key, request_timeout_seconds, verify_ssl_certificate):
-        headers = {'Authorization': 'Splunk %s' % auth_session_key}
-        response = requests.get(url, headers=headers, timeout=request_timeout_seconds, verify=verify_ssl_certificate)
+    def _do_get(self, url, request_timeout_seconds, verify_ssl_certificate):
+        response = self.requests_session.get(url, timeout=request_timeout_seconds, verify=verify_ssl_certificate)
         response.raise_for_status()
         return response
 
-    def do_post(self, url, auth_session_key, payload, request_timeout_seconds, verify_ssl_certificate):
+    def do_post(self, url, payload, request_timeout_seconds, verify_ssl_certificate):
         headers = {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Authorization': 'Splunk %s' % auth_session_key
+            'Content-Type': 'application/x-www-form-urlencoded'
         }
-        resp = requests.post(url, headers=headers, data=payload, timeout=request_timeout_seconds, verify=verify_ssl_certificate)
+        resp = self.requests_session.post(url, headers=headers, data=payload, timeout=request_timeout_seconds, verify=verify_ssl_certificate)
         try:
             resp.raise_for_status()
         except HTTPError as error:

--- a/utils/splunk/splunk_helper.py
+++ b/utils/splunk/splunk_helper.py
@@ -27,7 +27,7 @@ class SplunkHelper(object):
         """
         auth_url = '%s/services/auth/login?output_mode=json' % instance_config.base_url
         auth_username, auth_password = instance_config.get_auth_tuple()
-        payload = urlencode({'username': auth_username, 'password': auth_password})
+        payload = urlencode({'username': auth_username, 'password': auth_password, 'cookie': 1})
         response = self.do_post(auth_url, "", payload, instance_config.default_request_timeout_seconds, instance_config.verify_ssl_certificate).json()
         session_key = response["sessionKey"]
         return session_key

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -41,7 +41,7 @@ class SplunkTelemetryBase(AgentCheck):
         instance.update_status(current_time, self.status)
 
         try:
-            instance.instance_config.set_auth_session_key(self._auth_session(instance.instance_config))
+            self._auth_session(instance.instance_config)
 
             saved_searches = self._saved_searches(instance.instance_config)
             instance.saved_searches.update_searches(self.log, saved_searches)
@@ -51,7 +51,7 @@ class SplunkTelemetryBase(AgentCheck):
                 executed_searches |= self._dispatch_and_await_search(instance, saved_searches)
 
             if len(instance.saved_searches.searches) != 0 and not executed_searches:
-                raise CheckException("No saved search was successfully executed")
+                raise CheckException("No saved search was successfully executed.")
 
         except Exception as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=instance.tags, message=str(e))
@@ -175,7 +175,6 @@ class SplunkTelemetryBase(AgentCheck):
         :return:
         """
         dispatch_url = '%s/services/saved/searches/%s/dispatch' % (instance_config.base_url, quote(saved_search.name))
-        auth_session_key = instance_config.get_auth_session_key()
 
         parameters = saved_search.parameters
         # json output_mode is mandatory for response parsing
@@ -205,16 +204,16 @@ class SplunkTelemetryBase(AgentCheck):
 
         self.log.debug("Dispatching saved search: %s starting at %s." % (saved_search.name, parameters["dispatch.earliest_time"]))
 
-        response_body = self._do_post(dispatch_url, auth_session_key, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
+        response_body = self._do_post(dispatch_url, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
         return response_body['sid']
 
     def _auth_session(self, instance_config):
         """ This method is mocked for testing. Do not change its behavior """
-        return self.splunkHelper.auth_session(instance_config)
+        self.splunkHelper.auth_session(instance_config)
 
-    def _do_post(self, url, auth_session_key, payload, timeout, verify_ssl):
+    def _do_post(self, url, payload, timeout, verify_ssl):
         """ This method is mocked for testing. Do not change its behavior """
-        return self.splunkHelper.do_post(url, auth_session_key, payload, timeout, verify_ssl)
+        return self.splunkHelper.do_post(url, payload, timeout, verify_ssl)
 
     def _saved_searches(self, instance_config):
         """ This method is mocked for testing. Do not change its behavior """


### PR DESCRIPTION
Introduced Requests session, where we can store a session over multiple requests to Splunk. We don't have to pass session keys around.
The session will store a cookie or, as fallback, or previously, the Authentication header.