### PR TITLE
Make sure splunk helper is used per splunk instance, to assure credentials are not shared

### DIFF
--- a/tests/core/test_splunk_helper.py
+++ b/tests/core/test_splunk_helper.py
@@ -37,31 +37,7 @@ class TestSplunkHelper(unittest.TestCase):
     Test the Splunk Helper class
     """
 
-    @mock.patch('utils.splunk.splunk_helper.SplunkHelper.do_post',
-                return_value=FakeResponse(text="""{"sessionKey": "MySessionKeyForThisSession"}""",
-                                          headers={"Set-Cookie": "Set-Cookie: splunkd_8089=MySessionKeyForThisSession; Path=/; Secure; HttpOnly; Max-Age=3600; Expires=Mon, 09 Apr 2018 15:09:54 GMT"}))
-    def test_auth_session(self, mocked_do_post):
-        """
-        Test request authentication based on Cookie
-        retrieve auth session key,
-        set it to the requests session,
-        and see whether the outgoing request contains the expected HTTP header.
-        The expected HTTP header is Set-Cookie.
-        """
-        helper = SplunkHelper()
-        helper.auth_session(FakeInstanceConfig())
-
-        mocked_do_post.assert_called_with("http://testhost:8089/services/auth/login?output_mode=json", "username=username&password=password&cookie=1", 10, False)
-        mocked_do_post.assert_called_once()
-
-        header = helper.requests_session.headers.get("Set-Cookie")
-        self.assertTrue(header.startswith("Set-Cookie: splunkd_8089"))
-        header.index("MySessionKeyForThisSession")
-
-        # don't expect the Authentication header
-        self.assertFalse(helper.requests_session.headers.get("Authentication", False))
-
-    @mock.patch('utils.splunk.splunk_helper.SplunkHelper.do_post', return_value=FakeResponse("""{ "sessionKey": "MySessionKeyForThisSession" }""", headers={}))
+    @mock.patch('utils.splunk.splunk_helper.SplunkHelper._do_post', return_value=FakeResponse("""{ "sessionKey": "MySessionKeyForThisSession" }""", headers={}))
     def test_auth_session_fallback(self, mocked_do_post):
         """
         Test request authentication on fallback Authentication header
@@ -70,10 +46,10 @@ class TestSplunkHelper(unittest.TestCase):
         and see whether the outgoing request contains the expected HTTP header
         The expected HTTP header is Authentication when Set-Cookie is not present
         """
-        helper = SplunkHelper()
-        helper.auth_session(FakeInstanceConfig())
+        helper = SplunkHelper(FakeInstanceConfig())
+        helper.auth_session()
 
-        mocked_do_post.assert_called_with("http://testhost:8089/services/auth/login?output_mode=json", "username=username&password=password&cookie=1", 10, False)
+        mocked_do_post.assert_called_with("/services/auth/login?output_mode=json", "username=username&password=password&cookie=1", 10)
         mocked_do_post.assert_called_once()
 
         expected_header = helper.requests_session.headers.get("Authentication")

--- a/tests/core/test_utils_splunk.py
+++ b/tests/core/test_utils_splunk.py
@@ -1,18 +1,62 @@
 # stdlib
 import itertools
+from urllib import quote
 from unittest import TestCase
 
 import logging
+import mock
+import json
 
 from utils.splunk.splunk import SplunkSavedSearch, SplunkInstanceConfig, SavedSearches
 from utils.splunk.splunk_helper import SplunkHelper
 
 
+class FakeInstanceConfig(object):
+    def __init__(self):
+        self.base_url = 'http://testhost:8089'
+        self.default_request_timeout_seconds = 10
+        self.verify_ssl_certificate = False
+
+    def get_auth_tuple(self):
+        return ('username', 'password')
+
+
+class FakeResponse(object):
+    def __init__(self, text, status_code=200, headers={}):
+        self.status_code = status_code
+        self.payload = text
+        self.headers = headers
+
+    def json(self):
+        return json.loads(self.payload)
+
+    def raise_for_status(self):
+        return
+
+
 class TestUtilsSplunk(TestCase):
 
-    def test_splunk_helper(self):
+    @mock.patch('utils.splunk.splunk_helper.SplunkHelper._do_post',
+                return_value=FakeResponse("""{ "sessionKey": "MySessionKeyForThisSession" }""", headers={}))
+    def test_auth_session_fallback(self, mocked_do_post):
+        """
+        Test request authentication on fallback Authentication header
+        retrieve auth session key,
+        set it to the requests session,
+        and see whether the outgoing request contains the expected HTTP header
+        The expected HTTP header is Authentication when Set-Cookie is not present
+        """
+        helper = SplunkHelper(FakeInstanceConfig())
+        helper.auth_session()
 
-        splunk_helper = SplunkHelper()
+        mocked_do_post.assert_called_with("/services/auth/login?output_mode=json",
+                                          "username=username&password=password&cookie=1", 10)
+        mocked_do_post.assert_called_once()
+
+        expected_header = helper.requests_session.headers.get("Authentication")
+        self.assertEqual(expected_header, "Splunk MySessionKeyForThisSession")
+
+    def test_splunk_helper(self):
 
         instance_config = SplunkInstanceConfig({
             'url': 'dummy', 'username': 'admin', 'password': 'admin'
@@ -25,27 +69,26 @@ class TestUtilsSplunk(TestCase):
             'default_saved_searches_parallel': 3,
             'default_unique_key_fields': ["_bkt", "_cd"]
         })
+
+        splunk_helper = SplunkHelper(instance_config)
         saved_search = SplunkSavedSearch(instance_config, {"name": "search", "parameters": {}})
 
         search_offsets = []
 
         def _mocked_search_chunk(*args, **kwargs):
-            search_offsets.append(args[3])
-            if args[3] == 4000:
+            search_offsets.append(args[2])
+            if args[2] == 4000:
                 return {"messages": [], "results": []}
             else:
                 return {"messages": [], "results": list(itertools.repeat(None, 1000))}
 
         setattr(splunk_helper, "_search_chunk", _mocked_search_chunk)
 
-        res = splunk_helper.saved_search_results("id", saved_search, instance_config)
+        res = splunk_helper.saved_search_results("id", saved_search)
         self.assertEquals(len(res), 5)
         self.assertEquals(search_offsets, [0, 1000, 2000, 3000, 4000])
 
-
     def test_splunk_saved_searches(self):
-
-        splunk_helper = SplunkHelper()
 
         instance_config = SplunkInstanceConfig({
             'url': 'dummy', 'username': 'admin', 'password': 'admin'
@@ -58,6 +101,8 @@ class TestUtilsSplunk(TestCase):
             'default_saved_searches_parallel': 3,
             'default_unique_key_fields': ["_bkt", "_cd"]
         })
+
+        splunk_helper = SplunkHelper(instance_config)
 
         def _mocked_do_get(*args, **kwargs):
             class MockedResponse():
@@ -77,9 +122,44 @@ class TestUtilsSplunk(TestCase):
 
         setattr(splunk_helper, "_do_get", _mocked_do_get)
 
-        res = splunk_helper.saved_searches(instance_config)
+        res = splunk_helper.saved_searches()
         self.assertEquals(res, ["components", "relations"])
 
+    def test_splunk_dispatch(self):
+
+        instance_config = SplunkInstanceConfig({
+            'url': 'dummy', 'username': 'admin', 'password': 'admin'
+        }, {}, {
+            'default_request_timeout_seconds': 5,
+            'default_search_max_retry_count': 3,
+            'default_search_seconds_between_retries': 1,
+            'default_verify_ssl_certificate': False,
+            'default_batch_size': 1000,
+            'default_saved_searches_parallel': 3,
+            'default_unique_key_fields': ["_bkt", "_cd"]
+        })
+
+        splunk_helper = SplunkHelper(instance_config)
+        saved_search = SplunkSavedSearch(instance_config, {"name": "search", "parameters": {}})
+        params = {"key1": "val1", "key2": "val2"}
+
+        def _mocked_do_post(*args, **kwargs):
+            self.assertEquals(args,
+                              ('/services/saved/searches/%s/dispatch' % quote(saved_search.name),
+                               params,
+                               5
+                               ))
+
+            class MockedResponse():
+                def json(self):
+                    return {"sid": "zesid"}
+            return MockedResponse()
+
+
+        setattr(splunk_helper, "_do_post", _mocked_do_post)
+
+        res = splunk_helper.dispatch(saved_search, params)
+        self.assertEquals(res, "zesid")
 
 class TestSavedSearches(TestCase):
 

--- a/utils/splunk/splunk_helper.py
+++ b/utils/splunk/splunk_helper.py
@@ -1,7 +1,7 @@
 import time
 import requests
 import logging
-from urllib import urlencode
+from urllib import urlencode, quote
 
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from requests.exceptions import HTTPError
@@ -12,11 +12,12 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 class SplunkHelper(object):
 
-    def __init__(self):
+    def __init__(self, instance_config):
+        self.instance_config = instance_config
         self.log = logging.getLogger('%s' % __name__)
         self.requests_session = requests.session()
 
-    def auth_session(self, instance_config):
+    def auth_session(self):
         """
         retrieves a session token from Splunk to be used in subsequent requests
         session key expires after default 1 hour, configurable in Splunk: Settings -> Server -> General -> Session timeout
@@ -24,57 +25,52 @@ class SplunkHelper(object):
         Side affecting function.
         An expired key results in a 401 Unauthorized response with content:
           {"messages":[{"type":"WARN","text":"call not properly authenticated"}]}%
-        :param instance_config: InstanceConfig, current check configuration
         :return: nothing
         """
-        auth_url = '%s/services/auth/login?output_mode=json' % instance_config.base_url
-        auth_username, auth_password = instance_config.get_auth_tuple()
+        auth_path = '/services/auth/login?output_mode=json'
+        auth_username, auth_password = self.instance_config.get_auth_tuple()
         payload = urlencode({'username': auth_username, 'password': auth_password, 'cookie': 1})
-        response = self.do_post(auth_url, payload, instance_config.default_request_timeout_seconds, instance_config.verify_ssl_certificate)
+        response = self._do_post(auth_path, payload, self.instance_config.default_request_timeout_seconds)
         response.raise_for_status()
         response_json = response.json()
 
-        if 'Set-Cookie' in response.headers:
-            self.requests_session.headers.update({'Set-Cookie': response.headers['Set-Cookie']})
-        else:  # fallback to header, ref: http://docs.splunk.com/Documentation/Splunk/7.0.3/RESTREF/RESTaccess
-            session_key = response_json["sessionKey"]
-            self.requests_session.headers.update({'Authentication': "Splunk %s" % session_key})
+        # Fallback mechanism in case no cookies were passed by splunk.
+        session_key = response_json["sessionKey"]
+        self.requests_session.headers.update({'Authentication': "Splunk %s" % session_key})
 
-    def saved_searches(self, instance_config):
+    def saved_searches(self):
         """
         Retrieves a list of saved searches from splunk
-        :param instance_config: InstanceConfig, current check configuration
         :return: list of names of saved searches
         """
-        search_url = '%s/services/saved/searches?output_mode=json&count=-1' % instance_config.base_url
-        response = self._do_get(search_url, instance_config.default_request_timeout_seconds, instance_config.verify_ssl_certificate)
+        search_path = '/services/saved/searches?output_mode=json&count=-1'
+        response = self._do_get(search_path, self.instance_config.default_request_timeout_seconds, self.instance_config.verify_ssl_certificate)
         return [entry["name"] for entry in response.json()["entry"]]
 
-    def _search_chunk(self, instance_config, saved_search, search_id, offset, count):
+    def _search_chunk(self, saved_search, search_id, offset, count):
         """
         Retrieves the results of an already running splunk search, identified by the given search id.
-        :param instance_config: InstanceConfig, current check configuration
         :param saved_search: current SavedSearch being processed
         :param search_id: perform a search operation on the search id
         :param offset: starting offset, begin is 0, to start retrieving from
         :param count: the maximum number of elements expecting to be returned by the API call
         :return: raw json response from splunk
         """
-        search_url = '%s/services/search/jobs/%s/results?output_mode=json&offset=%s&count=%s' % (instance_config.base_url, search_id, offset, count)
-        response = self._do_get(search_url, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate)
+        search_path = '/services/search/jobs/%s/results?output_mode=json&offset=%s&count=%s' % (search_id, offset, count)
+        response = self._do_get(search_path, saved_search.request_timeout_seconds, self.instance_config.verify_ssl_certificate)
         retry_count = 0
 
         # retry until information is available.
         while response.status_code == 204:  # HTTP No Content response
             if retry_count == saved_search.search_max_retry_count:
-                raise CheckException("maximum retries reached for " + instance_config.base_url + " with search id " + search_id)
+                raise CheckException("maximum retries reached for " + self.instance_config.base_url + " with search id " + search_id)
             retry_count += 1
             time.sleep(saved_search.search_seconds_between_retries)
-            response = self._do_get(search_url, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate)
+            response = self._do_get(search_path, saved_search.request_timeout_seconds, self.instance_config.verify_ssl_certificate)
 
         return response.json()
 
-    def saved_search_results(self, search_id, saved_search, instance_config):
+    def saved_search_results(self, search_id, saved_search):
         """
         Perform a saved search, returns a list of responses that were received
         """
@@ -83,7 +79,7 @@ class SplunkHelper(object):
         nr_of_results = None
         results = []
         while nr_of_results is None or nr_of_results == saved_search.batch_size:
-            response = self._search_chunk(instance_config, saved_search, search_id, offset, saved_search.batch_size)
+            response = self._search_chunk(saved_search, search_id, offset, saved_search.batch_size)
             # received a message?
             for message in response['messages']:
                 if message['type'] == "FATAL":
@@ -94,16 +90,28 @@ class SplunkHelper(object):
             offset += nr_of_results
         return results
 
-    def _do_get(self, url, request_timeout_seconds, verify_ssl_certificate):
+    def dispatch(self, saved_search, parameters):
+        """
+        :param saved_search: The saved search to dispatch
+        :param parameters: Parameters of the saved search
+        :return: the sid of the saved search
+        """
+        dispatch_path = '/services/saved/searches/%s/dispatch' % quote(saved_search.name)
+        response_body = self._do_post(dispatch_path, parameters, saved_search.request_timeout_seconds).json()
+        return response_body["sid"]
+
+    def _do_get(self, path, request_timeout_seconds, verify_ssl_certificate):
+        url = "%s%s" % (self.instance_config.base_url, path)
         response = self.requests_session.get(url, timeout=request_timeout_seconds, verify=verify_ssl_certificate)
         response.raise_for_status()
         return response
 
-    def do_post(self, url, payload, request_timeout_seconds, verify_ssl_certificate):
+    def _do_post(self, path, payload, request_timeout_seconds):
         headers = {
             'Content-Type': 'application/x-www-form-urlencoded'
         }
-        resp = self.requests_session.post(url, headers=headers, data=payload, timeout=request_timeout_seconds, verify=verify_ssl_certificate)
+        url = "%s%s" % (self.instance_config.base_url, path)
+        resp = self.requests_session.post(url, headers=headers, data=payload, timeout=request_timeout_seconds, verify=self.instance_config.verify_ssl_certificate)
         try:
             resp.raise_for_status()
         except HTTPError as error:

--- a/utils/splunk/splunk_telemetry.py
+++ b/utils/splunk/splunk_telemetry.py
@@ -1,4 +1,5 @@
 from utils.splunk.splunk import SplunkSavedSearch
+from utils.splunk.splunk_helper import SplunkHelper
 
 
 class SplunkTelemetrySavedSearch(SplunkSavedSearch):
@@ -39,6 +40,7 @@ class SplunkTelemetrySavedSearch(SplunkSavedSearch):
 class SplunkTelemetryInstance(object):
     def __init__(self, current_time, instance, instance_config, saved_searches):
         self.instance_config = instance_config
+        self.splunkHelper = SplunkHelper(instance_config)
 
         # no saved searches may be configured
         if not isinstance(instance['saved_searches'], list):

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -213,7 +213,7 @@ class SplunkTelemetryBase(AgentCheck):
 
     def _auth_session(self, instance):
         """ This method is mocked for testing. Do not change its behavior """
-        instance.splunkHelper.auth_session(instance.instance_config)
+        instance.splunkHelper.auth_session()
 
     def _dispatch(self, instance, saved_search, parameters):
         """ This method is mocked for testing. Do not change its behavior """
@@ -221,11 +221,11 @@ class SplunkTelemetryBase(AgentCheck):
 
     def _saved_searches(self, instance):
         """ This method is mocked for testing. Do not change its behavior """
-        return instance.splunkHelper.saved_searches(instance.instance_config)
+        return instance.splunkHelper.saved_searches()
 
     def _search(self, search_id, saved_search, instance):
         """ This method is mocked for testing. Do not change its behavior """
-        return instance.splunkHelper.saved_search_results(search_id, saved_search, instance.instance_config)
+        return instance.splunkHelper.saved_search_results(search_id, saved_search)
 
     def _current_time_seconds(self):
         """ This method is mocked for testing. Do not change its behavior """


### PR DESCRIPTION
As the title says. Also factored out a dispatch function into splunk_helper.py and had it not call Set-Cookie when authenticating because this is handled by requests.Session() object itself