### PR TITLE
Splunk saved searches on app only visibility/permissions

### DIFF
--- a/tests/core/test_utils_splunk.py
+++ b/tests/core/test_utils_splunk.py
@@ -67,7 +67,8 @@ class TestUtilsSplunk(TestCase):
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
-            'default_unique_key_fields': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"],
+            'default_app': 'default'
         })
 
         splunk_helper = SplunkHelper(instance_config)
@@ -99,7 +100,8 @@ class TestUtilsSplunk(TestCase):
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
-            'default_unique_key_fields': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"],
+            'default_app': 'default'
         })
 
         splunk_helper = SplunkHelper(instance_config)
@@ -127,6 +129,8 @@ class TestUtilsSplunk(TestCase):
 
     def test_splunk_dispatch(self):
 
+        username = "admin"
+        appname = "myapp"
         instance_config = SplunkInstanceConfig({
             'url': 'dummy', 'username': 'admin', 'password': 'admin'
         }, {}, {
@@ -136,7 +140,8 @@ class TestUtilsSplunk(TestCase):
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
-            'default_unique_key_fields': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"],
+            'default_app': 'default'
         })
 
         splunk_helper = SplunkHelper(instance_config)
@@ -145,7 +150,7 @@ class TestUtilsSplunk(TestCase):
 
         def _mocked_do_post(*args, **kwargs):
             self.assertEquals(args,
-                              ('/services/saved/searches/%s/dispatch' % quote(saved_search.name),
+                              ('/servicesNS/%s/%s/saved/searches/%s/dispatch' % (username, appname, quote(saved_search.name)),
                                params,
                                5
                                ))
@@ -158,7 +163,7 @@ class TestUtilsSplunk(TestCase):
 
         setattr(splunk_helper, "_do_post", _mocked_do_post)
 
-        res = splunk_helper.dispatch(saved_search, params)
+        res = splunk_helper.dispatch(saved_search, username, appname, params)
         self.assertEquals(res, "zesid")
 
 class TestSavedSearches(TestCase):
@@ -176,7 +181,8 @@ class TestSavedSearches(TestCase):
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
-            'default_unique_key_fields': ["_bkt", "_cd"]
+            'default_unique_key_fields': ["_bkt", "_cd"],
+            'default_app': 'default'
         })
 
         saved_search_components = SplunkSavedSearch(instance_config, {"name": "components", "parameters": {}})

--- a/utils/splunk/splunk.py
+++ b/utils/splunk/splunk.py
@@ -30,6 +30,7 @@ class SplunkSavedSearch(object):
         self.search_max_retry_count = int(saved_search_instance.get('search_max_retry_count', instance_config.default_search_max_retry_count))
         self.search_seconds_between_retries = int(saved_search_instance.get('search_seconds_between_retries', instance_config.default_search_seconds_between_retries))
         self.batch_size = int(saved_search_instance.get('batch_size', instance_config.default_batch_size))
+        self.app = saved_search_instance.get("app", instance_config.default_app)
 
     def retrieve_fields(self, data):
         telemetry = {}
@@ -76,6 +77,7 @@ class SplunkInstanceConfig(object):
         self.default_verify_ssl_certificate = self.get_or_default('default_verify_ssl_certificate')
         self.default_batch_size = self.get_or_default('default_batch_size')
         self.default_saved_searches_parallel = self.get_or_default('default_saved_searches_parallel')
+        self.default_app = self.get_or_default('default_app')
 
         self.verify_ssl_certificate = bool(instance.get('verify_ssl_certificate', self.default_verify_ssl_certificate))
         self.base_url = instance['url']

--- a/utils/splunk/splunk_helper.py
+++ b/utils/splunk/splunk_helper.py
@@ -56,7 +56,7 @@ class SplunkHelper(object):
         :param count: the maximum number of elements expecting to be returned by the API call
         :return: raw json response from splunk
         """
-        search_path = '/services/search/jobs/%s/results?output_mode=json&offset=%s&count=%s' % (search_id, offset, count)
+        search_path = '/servicesNS/-/-/search/jobs/%s/results?output_mode=json&offset=%s&count=%s' % (search_id, offset, count)
         response = self._do_get(search_path, saved_search.request_timeout_seconds, self.instance_config.verify_ssl_certificate)
         retry_count = 0
 
@@ -90,13 +90,15 @@ class SplunkHelper(object):
             offset += nr_of_results
         return results
 
-    def dispatch(self, saved_search, parameters):
+    def dispatch(self, saved_search, splunk_owner, splunk_app, parameters):
         """
         :param saved_search: The saved search to dispatch
+        :param splunk_owner: Splunk user that dispatches the saved search
+        :param splunk_app: Splunk App under which the saved search is located
         :param parameters: Parameters of the saved search
         :return: the sid of the saved search
         """
-        dispatch_path = '/services/saved/searches/%s/dispatch' % quote(saved_search.name)
+        dispatch_path = '/servicesNS/%s/%s/saved/searches/%s/dispatch' % (splunk_owner, splunk_app, quote(saved_search.name))
         response_body = self._do_post(dispatch_path, parameters, saved_search.request_timeout_seconds).json()
         return response_body["sid"]
 

--- a/utils/splunk/splunk_helper.py
+++ b/utils/splunk/splunk_helper.py
@@ -90,15 +90,15 @@ class SplunkHelper(object):
             offset += nr_of_results
         return results
 
-    def dispatch(self, saved_search, splunk_owner, splunk_app, parameters):
+    def dispatch(self, saved_search, splunk_user, splunk_app, parameters):
         """
         :param saved_search: The saved search to dispatch
-        :param splunk_owner: Splunk user that dispatches the saved search
+        :param splunk_user: Splunk user that dispatches the saved search
         :param splunk_app: Splunk App under which the saved search is located
         :param parameters: Parameters of the saved search
         :return: the sid of the saved search
         """
-        dispatch_path = '/servicesNS/%s/%s/saved/searches/%s/dispatch' % (splunk_owner, splunk_app, quote(saved_search.name))
+        dispatch_path = '/servicesNS/%s/%s/saved/searches/%s/dispatch' % (splunk_user, splunk_app, quote(saved_search.name))
         response_body = self._do_post(dispatch_path, parameters, saved_search.request_timeout_seconds).json()
         return response_body["sid"]
 

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -220,7 +220,7 @@ class SplunkTelemetryBase(AgentCheck):
 
     def _dispatch(self, instance, saved_search, splunk_user, splunk_app, parameters):
         """ This method is mocked for testing. Do not change its behavior """
-        return instance.splunkHelper.dispatch(saved_search, splunk_owner, splunk_app, parameters)
+        return instance.splunkHelper.dispatch(saved_search, splunk_user, splunk_app, parameters)
 
     def _saved_searches(self, instance):
         """ This method is mocked for testing. Do not change its behavior """

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -187,6 +187,8 @@ class SplunkTelemetryBase(AgentCheck):
         parameters["output_mode"] = "json"
 
         earliest_epoch_datetime = get_utc_time(saved_search.last_observed_timestamp)
+        splunk_user = instance.instance_config.username
+        splunk_app = saved_search.app
 
         parameters["dispatch.time_format"] = self.TIME_FMT
         parameters["dispatch.earliest_time"] = earliest_epoch_datetime.strftime(self.TIME_FMT)
@@ -210,15 +212,15 @@ class SplunkTelemetryBase(AgentCheck):
 
         self.log.debug("Dispatching saved search: %s starting at %s." % (saved_search.name, parameters["dispatch.earliest_time"]))
 
-        return self._dispatch(instance, saved_search, parameters)
+        return self._dispatch(instance, saved_search, splunk_user, splunk_app, parameters)
 
     def _auth_session(self, instance):
         """ This method is mocked for testing. Do not change its behavior """
         instance.splunkHelper.auth_session()
 
-    def _dispatch(self, instance, saved_search, parameters):
+    def _dispatch(self, instance, saved_search, splunk_user, splunk_app, parameters):
         """ This method is mocked for testing. Do not change its behavior """
-        return instance.splunkHelper.dispatch(saved_search, parameters)
+        return instance.splunkHelper.dispatch(saved_search, splunk_owner, splunk_app, parameters)
 
     def _saved_searches(self, instance):
         """ This method is mocked for testing. Do not change its behavior """

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -146,7 +146,8 @@ class SplunkTelemetryBase(AgentCheck):
                 event_tags.extend(instance.tags)
                 telemetry.update({"tags": event_tags, "timestamp": timestamp})
                 yield telemetry
-            except Exception:
+            except Exception as e:
+                self.log.exception(e)
                 yield None
 
     def _apply(self, **kwargs):


### PR DESCRIPTION
Our Splunk integration requires the saved searches to be displayed for all apps, can be set in the permissions page of a saved search. Our API assumed that the saved searches were public/visible to all apps.

This MR supports saved searches with permissions set to app only by using a different API endpoint. The user which is used to log in is used to dispatch the saved searches.

It is now required to provide a splunk app's per saved search. The default app is 'search', where all public visible saved searches can still be found. 

Existing Functionality should be unchanged.

There is an accompanying PR for integrations-core.