### PR TITLE
Default dispatch parameters

### DIFF
--- a/tests/core/test_utils_splunk.py
+++ b/tests/core/test_utils_splunk.py
@@ -68,7 +68,8 @@ class TestUtilsSplunk(TestCase):
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
             'default_unique_key_fields': ["_bkt", "_cd"],
-            'default_app': 'default'
+            'default_app': 'default',
+            'default_parameters': {}
         })
 
         splunk_helper = SplunkHelper(instance_config)
@@ -101,7 +102,8 @@ class TestUtilsSplunk(TestCase):
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
             'default_unique_key_fields': ["_bkt", "_cd"],
-            'default_app': 'default'
+            'default_app': 'default',
+            'default_parameters': {}
         })
 
         splunk_helper = SplunkHelper(instance_config)
@@ -141,7 +143,8 @@ class TestUtilsSplunk(TestCase):
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
             'default_unique_key_fields': ["_bkt", "_cd"],
-            'default_app': 'default'
+            'default_app': 'default',
+            'default_parameters': {}
         })
 
         splunk_helper = SplunkHelper(instance_config)
@@ -182,7 +185,8 @@ class TestSavedSearches(TestCase):
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
             'default_unique_key_fields': ["_bkt", "_cd"],
-            'default_app': 'default'
+            'default_app': 'default',
+            'default_parameters': {}
         })
 
         saved_search_components = SplunkSavedSearch(instance_config, {"name": "components", "parameters": {}})

--- a/utils/splunk/splunk.py
+++ b/utils/splunk/splunk.py
@@ -24,8 +24,7 @@ class SplunkSavedSearch(object):
         self.optional_fields = None  # allowed to be absent
         self.fixed_fields = None  # fields that are filled in by the check
 
-        self.parameters = saved_search_instance['parameters']
-
+        self.parameters = dict(saved_search_instance.get("parameters", instance_config.default_parameters))
         self.request_timeout_seconds = int(saved_search_instance.get('request_timeout_seconds', instance_config.default_request_timeout_seconds))
         self.search_max_retry_count = int(saved_search_instance.get('search_max_retry_count', instance_config.default_search_max_retry_count))
         self.search_seconds_between_retries = int(saved_search_instance.get('search_seconds_between_retries', instance_config.default_search_seconds_between_retries))
@@ -78,6 +77,7 @@ class SplunkInstanceConfig(object):
         self.default_batch_size = self.get_or_default('default_batch_size')
         self.default_saved_searches_parallel = self.get_or_default('default_saved_searches_parallel')
         self.default_app = self.get_or_default('default_app')
+        self.default_parameters = self.get_or_default('default_parameters')
 
         self.verify_ssl_certificate = bool(instance.get('verify_ssl_certificate', self.default_verify_ssl_certificate))
         self.base_url = instance['url']


### PR DESCRIPTION
Splunk saved searches were always dispatched with parameters 'dispatch.now' and 'force_dispatch'. This PR removes the requirement of specifying them per saved search and just assume these parameters as default. Now you can just provide a neat list of saved searches.