### PR TITLE
pass ignore saved search flag as false default

### DIFF
--- a/utils/splunk/splunk.py
+++ b/utils/splunk/splunk.py
@@ -83,6 +83,7 @@ class SplunkInstanceConfig(object):
         self.base_url = instance['url']
         self.username = instance['username']
         self.password = instance['password']
+        self.ignore_saved_search_errors = instance.get('ignore_saved_search_errors', False)
 
     def get_or_default(self, field):
         return self.init_config.get(field, self.defaults[field])

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -198,7 +198,7 @@ class SplunkTelemetryBase(AgentCheck):
         earliest_epoch_datetime = get_utc_time(saved_search.last_observed_timestamp)
         splunk_user = instance.instance_config.username
         splunk_app = saved_search.app
-        ignore_saved_search_errors = instance.ignore_saved_search_errors
+        ignore_saved_search_errors = instance.instance_config.ignore_saved_search_errors
 
         parameters["dispatch.time_format"] = self.TIME_FMT
         parameters["dispatch.earliest_time"] = earliest_epoch_datetime.strftime(self.TIME_FMT)

--- a/utils/splunk/splunk_telemetry_base.py
+++ b/utils/splunk/splunk_telemetry_base.py
@@ -198,6 +198,7 @@ class SplunkTelemetryBase(AgentCheck):
         earliest_epoch_datetime = get_utc_time(saved_search.last_observed_timestamp)
         splunk_user = instance.instance_config.username
         splunk_app = saved_search.app
+        ignore_saved_search_errors = instance.ignore_saved_search_errors
 
         parameters["dispatch.time_format"] = self.TIME_FMT
         parameters["dispatch.earliest_time"] = earliest_epoch_datetime.strftime(self.TIME_FMT)
@@ -221,15 +222,15 @@ class SplunkTelemetryBase(AgentCheck):
 
         self.log.debug("Dispatching saved search: %s starting at %s." % (saved_search.name, parameters["dispatch.earliest_time"]))
 
-        return self._dispatch(instance, saved_search, splunk_user, splunk_app, parameters)
+        return self._dispatch(instance, saved_search, splunk_user, splunk_app, ignore_saved_search_errors, parameters)
 
     def _auth_session(self, instance):
         """ This method is mocked for testing. Do not change its behavior """
         instance.splunkHelper.auth_session()
 
-    def _dispatch(self, instance, saved_search, splunk_user, splunk_app, parameters):
+    def _dispatch(self, instance, saved_search, splunk_user, splunk_app, ignore_saved_search_errors, parameters):
         """ This method is mocked for testing. Do not change its behavior """
-        return instance.splunkHelper.dispatch(saved_search, splunk_user, splunk_app, parameters)
+        return instance.splunkHelper.dispatch(saved_search, splunk_user, splunk_app, ignore_saved_search_errors, parameters)
 
     def _finalize_sid(self, instance, sid, saved_search):
         """ This method is mocked for testing. Do not change its behavior """


### PR DESCRIPTION
Introduction of `ignore_saved_search_errors` flag in Splunk topology introduced error in Splunk metric and event because it uses the common `Splunk dispatch` API. So pass the flag as `False` by default for now. 