### PR TITLE
Add a docker image that will run the collector and forwarder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:latest
+
+COPY rootfs/usr /usr/
+COPY rootfs/etc/supervisor.conf /etc/supervisor.conf
+
+RUN apt-get -qy update && \
+  apt-get install -qy wget && \
+  wget -q https://5fzd4zyw2d.execute-api.eu-west-1.amazonaws.com/prod/getfile/stackstate-agent_1.3.0-1_amd64.deb?licencekey=89B30-03X84-D33B3 -O agent.deb && \
+  apt-get install -qy ./agent.deb && \
+  /usr/local/bin/apt_clean && \
+  rm agent.deb
+
+# Prepare agent setup
+RUN mkdir /var/log/stackstate && \
+  chown sts-agent:sts-agent /var/log/stackstate && \
+  cp /etc/sts-agent/stackstate.conf.example /etc/sts-agent/stackstate.conf
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint" ]

--- a/docker/rootfs/etc/supervisor.conf
+++ b/docker/rootfs/etc/supervisor.conf
@@ -1,0 +1,51 @@
+[supervisorctl]
+serverurl = unix:///opt/stackstate-agent/run/stackstate-supervisor.sock
+
+[unix_http_server]
+file=/opt/stackstate-agent/run/stackstate-supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisord]
+http_port = /opt/stackstate-agent/run/stackstate-supervisor.sock
+minfds = 1024
+minprocs = 200
+loglevel = info
+logfile = /var/log/stackstate/supervisord.log
+logfile_maxbytes = 10MB
+nodaemon = false
+pidfile = /opt/stackstate-agent/run/stackstate-supervisord.pid
+logfile_backups = 1
+user=root
+environment=PYTHONPATH=/opt/stackstate-agent/agent,LANG=POSIX
+
+[program:collector]
+command=/opt/stackstate-agent/embedded/bin/python /opt/stackstate-agent/agent/agent.py foreground --use-local-forwarder
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=999
+startsecs=5
+startretries=3
+user=sts-agent
+environment=PYTHONPATH='/opt/stackstate-agent/agent:/opt/stackstate-agent/agent/checks/libs:$PYTHONPATH'
+
+[program:forwarder]
+command=/opt/stackstate-agent/embedded/bin/python /opt/stackstate-agent/agent/stsagent.py
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+startsecs=5
+startretries=3
+priority=998
+user=sts-agent
+
+[eventlistener:processes]
+command=/usr/local/bin/stop_supervisord
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+
+[group:stackstate-agent]
+programs=forwarder,collector

--- a/docker/rootfs/usr/local/bin/apt_clean
+++ b/docker/rootfs/usr/local/bin/apt_clean
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Apt cleaner for Docker images
+apt-get -qy autoremove
+apt-get -qy clean autoclean
+rm -rf /var/cache/apt/*
+rm -rf /var/lib/apt/lists/*
+rm -rf /var/log/*

--- a/docker/rootfs/usr/local/bin/entrypoint
+++ b/docker/rootfs/usr/local/bin/entrypoint
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+PATH=/opt/stackstate-agent/embedded/bin:/opt/stackstate-agent/bin:$PATH
+
+exec /opt/stackstate-agent/bin/supervisord -n -c /etc/supervisor.conf
+
+#tail -f /var/log/stackstate/collector.log /var/log/stackstate/collector.log /var/log/stackstate/supervisord.log

--- a/docker/rootfs/usr/local/bin/stop_supervisord
+++ b/docker/rootfs/usr/local/bin/stop_supervisord
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+printf "READY\n";
+
+while read line; do
+  echo "Processing Event: $line" >&2;
+  kill -SIGQUIT $PPID
+done < /dev/stdin


### PR DESCRIPTION
The image will only run the collector and forwarder (and supervisord to manage those 2) since the main use-case is only the data scraping checks of the collector, for example Splunk data.